### PR TITLE
adding report file upload

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Requirements:
 ![slack_item](/docs/images/slack_item.png)
 
 #### Slack Settings
-- Uncheck *Using Slack*, and enter your Slack [Authentication Token](https://get.slack.help/hc/en-us/articles/215770388-Create-and-regenerate-API-tokens) and a [channel](https://get.slack.help/hc/en-us/categories/200111606-Using-Slack#work-in-channels) name.
+- Uncheck *Using Slack*, and enter your Slack [Authentication Token](https://get.slack.help/hc/en-us/articles/215770388-Create-and-regenerate-API-tokens), a [channel](https://get.slack.help/hc/en-us/categories/200111606-Using-Slack#work-in-channels) name, and the location of your report directory (leave blank to only report test results summary)
 - Click the *Test Connection* to check your credentials. If everything is OK, a message should be sent to Slack.
 
 ![test_message](/docs/images/test_message.png)
@@ -31,3 +31,7 @@ Requirements:
 - Execute a test suite and wait for the execution finished, a summary message should be sent to your Slack channel.
 
 ![summary_message](/docs/images/summary_message.png)
+
+#### Report file upload
+- If you have generated reports with the report plug in, and you have indicated the location of your Reports folder in the Slack Integration settings, any report files (html, csv, or pdf) found under the ID for test suites executed will be uploaded to the same Slack channel.
+- this requires the *files:write:user* scope for your app.

--- a/pom.xml
+++ b/pom.xml
@@ -35,6 +35,22 @@
 			<artifactId>gson</artifactId>
 			<version>2.8.5</version>
 		</dependency>
+		<dependency>
+			<groupId>commons-io</groupId>
+			<artifactId>commons-io</artifactId>
+			<version>2.6</version>
+		  </dependency>
+		  <dependency>
+			  <groupId>org.apache.httpcomponents</groupId>
+			  <artifactId>httpclient</artifactId>
+			  <version>4.3.6</version>
+			</dependency>
+			<!-- mvnrepository.com/artifact/org.apache.httpcomponents/httpmime -->
+			<dependency>
+				<groupId>org.apache.httpcomponents</groupId>
+				<artifactId>httpmime</artifactId>
+				<version>4.3.6</version>
+			</dependency>
 	</dependencies>
 
 	<properties>

--- a/src/main/java/com/katalon/plugin/slack/SlackConstants.java
+++ b/src/main/java/com/katalon/plugin/slack/SlackConstants.java
@@ -10,4 +10,6 @@ public interface SlackConstants {
     String PREF_AUTH_TOKEN = "authentication.token";
     
     String PREF_AUTH_CHANNEL = "authentication.channel";
+
+    String PREF_REPORT_DIR = "reports.directory";
 }

--- a/src/main/java/com/katalon/plugin/slack/SlackEventListenerInitializer.java
+++ b/src/main/java/com/katalon/plugin/slack/SlackEventListenerInitializer.java
@@ -1,7 +1,8 @@
 package com.katalon.plugin.slack;
 
+import org.apache.commons.io.FilenameUtils;
 import org.osgi.service.event.Event;
-
+import java.io.File;
 import com.katalon.platform.api.event.EventListener;
 import com.katalon.platform.api.event.ExecutionEvent;
 import com.katalon.platform.api.exception.ResourceException;
@@ -10,6 +11,11 @@ import com.katalon.platform.api.extension.EventListenerInitializer;
 import com.katalon.platform.api.preference.PluginPreference;
 
 public class SlackEventListenerInitializer implements EventListenerInitializer, SlackComponent {
+
+    String authToken;
+    String channel;
+    String reportDir;
+    String apiToken;
 
     @Override
     public void registerListener(EventListener listener) {
@@ -20,9 +26,10 @@ public class SlackEventListenerInitializer implements EventListenerInitializer, 
                 if (!isIntegrationEnabled) {
                     return;
                 }
-                String authToken = preferences.getString(SlackConstants.PREF_AUTH_TOKEN, "");
-                String channel = preferences.getString(SlackConstants.PREF_AUTH_CHANNEL, "");
-
+                authToken = preferences.getString(SlackConstants.PREF_AUTH_TOKEN, "");
+                channel = preferences.getString(SlackConstants.PREF_AUTH_CHANNEL, "");
+                reportDir = preferences.getString(SlackConstants.PREF_REPORT_DIR, "");
+                apiToken = preferences.getString(SlackConstants.PREF_AUTH_TOKEN, "");
                 if (ExecutionEvent.TEST_SUITE_FINISHED_EVENT.equals(event.getTopic())) {
                     ExecutionEvent eventObject = (ExecutionEvent) event.getProperty("org.eclipse.e4.data");
 
@@ -30,7 +37,7 @@ public class SlackEventListenerInitializer implements EventListenerInitializer, 
                             .getExecutionContext();
                     TestSuiteStatusSummary testSuiteSummary = TestSuiteStatusSummary.of(testSuiteContext);
                     System.out.println("Slack: Start sending summary message to channel: " + channel);
-                    String message = "Summary execution result of test suite: " + testSuiteContext.getSourceId()
+                    String message = "Summary execution result of test suite: " + testSuiteContext.getSourceId() + ", ID: " + testSuiteContext.getId() 
                             + "\nTotal test cases: " + Integer.toString(testSuiteSummary.getTotalTestCases())
                             + "\nTotal passes: " + Integer.toString(testSuiteSummary.getTotalPasses())
                             + "\nTotal failures: " + Integer.toString(testSuiteSummary.getTotalFailures())
@@ -39,10 +46,51 @@ public class SlackEventListenerInitializer implements EventListenerInitializer, 
                     SlackUtil.sendMessage(authToken, channel, message);
 
                     System.out.println("Slack: Summary message has been successfully sent");
+                    // check and see if report exists, if so, send it:
+                    reportDir.trim();
+                    if(!reportDir.isEmpty()){
+                        File dir = new File(reportDir);
+                        FolderFinder(dir, testSuiteContext);
+                    }
                 }
             } catch (ResourceException | SlackException e) {
                 e.printStackTrace(System.err);
             }
         });
+    }
+
+    //dig through folders to find the correct report folder for this execution
+    //necessary because Suite Collections nest the folder under other IDs' folders
+    public void FolderFinder(File dir, TestSuiteExecutionContext context) throws SlackException {
+        File[] directoryListing = dir.listFiles();
+        if (directoryListing != null) {
+            for (File child : directoryListing) {
+                if (child.isDirectory()) {
+                   if(child.getName().equals(context.getId())){
+                        ReportFinder(child, context);
+                   }
+                   else{
+                       FolderFinder(child, context);
+                   }
+                }
+            }
+        }
+    }
+
+    //dig through report folder to find the reports
+    public void ReportFinder(File dir, TestSuiteExecutionContext context) throws SlackException {
+        File[] directoryListing = dir.listFiles();
+        if (directoryListing != null) {
+            for (File child : directoryListing) {
+                if (child.isDirectory()) {
+                    ReportFinder(child, context);
+                } else {
+                    String ext = FilenameUtils.getExtension(child.getName());
+                    if (ext.equals("pdf") || ext.equals("html") || ext.equals("csv")) {
+                        SlackUtil.sendFile(authToken, channel, context.getSourceId(), context.getId(), child);
+                    }
+                }
+            }
+        }
     }
 }

--- a/src/main/java/com/katalon/plugin/slack/SlackPreferencePage.java
+++ b/src/main/java/com/katalon/plugin/slack/SlackPreferencePage.java
@@ -31,6 +31,8 @@ public class SlackPreferencePage extends PreferencePage implements SlackComponen
 
     private Text txtChannel;
 
+    private Text txtReport;
+
     private Composite container;
 
     private Button btnTestConnection;
@@ -66,11 +68,18 @@ public class SlackPreferencePage extends PreferencePage implements SlackComponen
         txtToken.setLayoutData(gdTxtToken);
 
         Label lblChannel = new Label(grpAuthentication, SWT.NONE);
-        lblChannel.setText("Chanel/Group");
+        lblChannel.setText("Channel/Group");
         lblToken.setLayoutData(gdLabel);
 
         txtChannel = new Text(grpAuthentication, SWT.BORDER);
         txtChannel.setLayoutData(new GridData(SWT.FILL, SWT.TOP, true, false));
+
+        Label lblReport = new Label(grpAuthentication, SWT.NONE);
+        lblReport.setText("Report Folder (empty = no upload)");
+        lblReport.setLayoutData(gdLabel);
+
+        txtReport = new Text(grpAuthentication, SWT.BORDER);
+        txtReport.setLayoutData(new GridData(SWT.FILL, SWT.TOP, true, false));
 
         btnTestConnection = new Button(grpAuthentication, SWT.PUSH);
         btnTestConnection.setText("Test Connection");
@@ -159,6 +168,7 @@ public class SlackPreferencePage extends PreferencePage implements SlackComponen
             pluginStore.setBoolean(SlackConstants.PREF_IS_SLACK_ENABLED, chckEnableIntegration.getSelection());
             pluginStore.setString(SlackConstants.PREF_AUTH_TOKEN, txtToken.getText());
             pluginStore.setString(SlackConstants.PREF_AUTH_CHANNEL, txtChannel.getText());
+            pluginStore.setString(SlackConstants.PREF_REPORT_DIR, txtReport.getText());
 
             pluginStore.save();
             return true;
@@ -177,6 +187,7 @@ public class SlackPreferencePage extends PreferencePage implements SlackComponen
 
             txtToken.setText(pluginStore.getString(SlackConstants.PREF_AUTH_TOKEN, ""));
             txtChannel.setText(pluginStore.getString(SlackConstants.PREF_AUTH_CHANNEL, ""));
+            txtReport.setText(pluginStore.getString(SlackConstants.PREF_REPORT_DIR, ""));
 
             container.layout(true, true);
         } catch (ResourceException e) {


### PR DESCRIPTION
Report folder location in slack config in UI will now indicate if report files should be uploaded or not.

If a location is added (and the app has the appropriate scope in Slack) files matching the test suite ID will now be uploaded to configured Slack channel.